### PR TITLE
Add `@pnpm.e2e/pkg-with-accidentally-published-catalog-protocol`

### DIFF
--- a/packages/pkg-with-accidentally-published-catalog-protocol/package.json
+++ b/packages/pkg-with-accidentally-published-catalog-protocol/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@pnpm.e2e/pkg-with-accidentally-published-catalog-protocol",
+  "version": "1.0.0",
+  "dependencies": {
+    "@pnpm.e2e/hello-world-js-bin": "catalog:foo"
+  }
+}


### PR DESCRIPTION
## Changes

Adding a package that uses the `catalog:` protocol.

## Motivation

I'd like to add a test in pnpm to ensure we show a clear error when a package using the `catalog:` protocol is published without the protocol being transformed. At the moment pnpm will show:

```
ERR_PNPM_SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER  foo@catalog: isn't supported by any available resolver.
```

I think it'll be more helpful to show an error that a `catalog` specifier was found in an external dependency, and that this is a bug in that external dependency.