### PR TITLE
feat: add `for-testing-pnpm-dlx`

### DIFF
--- a/packages/for-testing-pnpm-dlx/foo.js
+++ b/packages/for-testing-pnpm-dlx/foo.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+const fs = require('fs')
+
+fs.writeFileSync('foo', '', 'utf8')

--- a/packages/for-testing-pnpm-dlx/package.json
+++ b/packages/for-testing-pnpm-dlx/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@pnpm.e2e/for-testing-pnpm-dlx",
+  "version": "1.0.0",
+  "description": "Contains a 'foo' bin for testing pnpm dlx",
+  "bin": {
+    "foo": "foo.js"
+  },
+  "author": "Zoltan Kochan",
+  "license": "MIT"
+}


### PR DESCRIPTION
Context: https://github.com/pnpm/pnpm/pull/9260#discussion_r1987025460

Copying https://github.com/zkochan/for-testing-pnpm-dlx into `@pnpm/registry-mock` to avoid reading from github.com during pnpm CI tests.

I suspect fetching from github.com is more flaky since it has rate-limits.