### PR TITLE
chore(release): 4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/registry-mock",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Mock the npm registry",
   "main": "dist/index.js",
   "bin": "dist/bin/pnpm-registry-mock.js",


### PR DESCRIPTION
Updating the version field to fix a publishing error.

https://github.com/pnpm/registry-mock/actions/runs/13778475439/job/38532258440

```
npm notice Publishing to https://registry.npmjs.org/ with tag latest and default access
npm error code E403
npm error 403 403 Forbidden - PUT https://registry.npmjs.org/@pnpm%2fregistry-mock - You cannot publish over the previously published versions: 4.0.0.
```