### PR TITLE
fix: remove `require.resolve`

### DIFF
--- a/packages/support-different-architectures/index.js
+++ b/packages/support-different-architectures/index.js
@@ -11,10 +11,7 @@ function getOptionalDependencies () {
 
   for (const packageName in optionalDependencies) {
     try {
-      installed[packageName] = {
-        path: require.resolve(packageName),
-        manifest: require(`${packageName}/package.json`),
-      }
+      installed[packageName] = require(`${packageName}/package.json`)
     } catch (error) {
       if (error.code === 'MODULE_NOT_FOUND') {
         notInstalled.push(packageName)


### PR DESCRIPTION
I missed that `require.resolve(pkgName)` didn't work because none of the dependencies have `index.js`.